### PR TITLE
Fix rvalueref whitespace

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -3541,7 +3541,7 @@ def IsRValueType(typenames, clean_lines, nesting_state, linenum, column):
     # We want to skip over identifiers and commas to get to a symbol.
     # Commas are skipped so that we can find the opening parenthesis
     # for function parameter lists.
-    match_symbol = Match(r'^(.*)([^\w\s,])[\w\s,]*$', line)
+    match_symbol = Match(r'^(.*)([^\w\s,:&*])[\w\s,:&*]*$', line)
     if match_symbol:
       break
     start -= 1

--- a/cpplint.py
+++ b/cpplint.py
@@ -2470,7 +2470,7 @@ class NestingState(object):
     #   class LOCKABLE API Object {
     #   };
     class_decl_match = Match(
-        r'^(\s*(?:template\s*<[\w\s<>,:]*>\s*)?'
+        r'^(\s*(?:template\s*<[\w\s<>,:=]*>\s*)?'
         r'(class|struct)\s+(?:[A-Z_]+\s+)*(\w+(?:::\w+)*))'
         r'(.*)$', line)
     if (class_decl_match and

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -1007,6 +1007,22 @@ class CpplintTest(CpplintTestBase):
 
   def testRawStrings(self):
     self.TestMultiLineLint(
+      """
+      int main() {
+        struct A {
+           A(std::string s, A&& a);
+        };
+      }""",
+        'RValue references are an unapproved C++ feature.  [build/c++11] [3]')
+
+    self.TestMultiLineLint(
+      """
+      template <class T, class D = default_delete<T>> class unique_ptr {
+       public:
+          unique_ptr(unique_ptr&& u) noexcept;
+      };""",
+        'RValue references are an unapproved C++ feature.  [build/c++11] [3]')
+    self.TestMultiLineLint(
         """
         void Func() {
           static const char kString[] = R"(
@@ -2577,6 +2593,9 @@ class CpplintTest(CpplintTestBase):
     self.TestLint('const a&& b = c;', rvalue_error)
     self.TestLint('struct a&& b = c;', rvalue_error)
     self.TestLint('decltype(a)&& b = c;', rvalue_error)
+    self.TestLint('A(int s, A&& a);', rvalue_error)
+    self.TestLint('A(std::string s, A&& a);', rvalue_error)
+    self.TestLint('unique_ptr(unique_ptr&& u) noexcept;', rvalue_error)
 
     # Cast expressions
     self.TestLint('a = const_cast<b&&>(c);', rvalue_error)
@@ -5439,6 +5458,12 @@ class NestingStateTest(unittest.TestCase):
     self.assertEquals(len(self.nesting_state.stack), 1)
     self.assertTrue(isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
     self.assertEquals(self.nesting_state.stack[0].name, 'K')
+
+  def testTemplateDefaultArg(self):
+    self.UpdateWithLines([
+      'template <class T, class D = default_delete<T>> class unique_ptr {',])
+    self.assertEquals(len(self.nesting_state.stack), 1)
+    self.assertTrue(self.nesting_state.stack[0], isinstance(self.nesting_state.stack[0], cpplint._ClassInfo))
 
   def testTemplateInnerClass(self):
     self.UpdateWithLines(['class A {',

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -2595,6 +2595,8 @@ class CpplintTest(CpplintTestBase):
     self.TestLint('decltype(a)&& b = c;', rvalue_error)
     self.TestLint('A(int s, A&& a);', rvalue_error)
     self.TestLint('A(std::string s, A&& a);', rvalue_error)
+    self.TestLint('A(const std::string &s, A&& a);', rvalue_error)
+    self.TestLint('A(int* s, A&& a);', rvalue_error)
     self.TestLint('unique_ptr(unique_ptr&& u) noexcept;', rvalue_error)
 
     # Cast expressions


### PR DESCRIPTION
@itamaro if you have time, please review this too. The unit test fail without the fix, I think they may demonstrate the 2 bugs.
Mostly you should check wether this introduces false positives, or whether you see any other chars missing in those regeses to fix more similar issues.

Honestly, after digging through this code to find the bug(?), I understand why Google does not maintain cpplint anymore.