### PR TITLE
Using namespace literals

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -4893,7 +4893,7 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
           'Did you mean "memset(%s, 0, %s)"?'
           % (match.group(1), match.group(2)))
 
-  if Search(r'\busing namespace\b', line):
+  if Search(r'\busing namespace\b', line) and not Search(r'\bliterals\b', line):
     error(filename, linenum, 'build/namespaces', 5,
           'Do not use namespace using-directives.  '
           'Use using-declarations instead.')

--- a/cpplint.py
+++ b/cpplint.py
@@ -191,6 +191,7 @@ _ERROR_CATEGORIES = [
     'build/include_alpha',
     'build/include_order',
     'build/include_what_you_use',
+    'build/namespaces_literals',
     'build/namespaces',
     'build/printf_format',
     'build/storage_class',
@@ -4893,10 +4894,15 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
           'Did you mean "memset(%s, 0, %s)"?'
           % (match.group(1), match.group(2)))
 
-  if Search(r'\busing namespace\b', line) and not Search(r'\bliterals\b', line):
-    error(filename, linenum, 'build/namespaces', 5,
-          'Do not use namespace using-directives.  '
-          'Use using-declarations instead.')
+  if Search(r'\busing namespace\b', line):
+    if Search(r'\bliterals\b', line):
+      error(filename, linenum, 'build/namespaces_literals', 5,
+            'Do not use namespace using-directives.  '
+            'Use using-declarations instead.')
+    else:
+      error(filename, linenum, 'build/namespaces', 5,
+            'Do not use namespace using-directives.  '
+            'Use using-declarations instead.')
 
   # Detect variable-length arrays.
   match = Match(r'\s*(.+::)?(\w+) [a-z]\w*\[(.+)];', line)

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3002,6 +3002,10 @@ class CpplintTest(CpplintTestBase):
     DoTest(self, ['', '', '', 'using namespace foo;'])
     DoTest(self, ['// hello', 'using namespace foo;'])
 
+  def testUsingLiteralsNamespaces(self):
+    self.TestLint('using namespace std::literals;', '')
+    self.TestLint('using namespace std::literals::chrono_literals;', '')
+
   def testNewlineAtEOF(self):
     def DoTest(self, data, is_missing_eof):
       error_collector = ErrorCollector(self.assert_)

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3003,8 +3003,8 @@ class CpplintTest(CpplintTestBase):
     DoTest(self, ['// hello', 'using namespace foo;'])
 
   def testUsingLiteralsNamespaces(self):
-    self.TestLint('using namespace std::literals;', '')
-    self.TestLint('using namespace std::literals::chrono_literals;', '')
+    self.TestLint('using namespace std::literals;', 'Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces_literals] [5]')
+    self.TestLint('using namespace std::literals::chrono_literals;', 'Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces_literals] [5]')
 
   def testNewlineAtEOF(self):
     def DoTest(self, data, is_missing_eof):


### PR DESCRIPTION
This reopens #16, which has been reverted. I believe making exceptions for literal namespaces is fine, but should be done with a special rule "build/namespaceliterals" or so, such warnings for namespace literals may be ignored if the user passes `-build/namespaceliterals` to cpplint. This should maybe be implied in `-build/namespaces`.
